### PR TITLE
refactor: simplify voice recording logic by removing unused audio buf…

### DIFF
--- a/lib/view_model/voice_record/voice_record_view_model.dart
+++ b/lib/view_model/voice_record/voice_record_view_model.dart
@@ -1,7 +1,5 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:flutter/widgets.dart';
 import 'package:just_audio/just_audio.dart';
@@ -11,127 +9,47 @@ import 'package:record/record.dart';
 class VoiceRecordViewModel extends ChangeNotifier {
   final _recorder = AudioRecorder();
   final _player = AudioPlayer();
-  final List<int> _audioBuffer = [];
-  StreamSubscription<Uint8List>? _streamSubscription;
 
   bool _isRecording = false;
   bool get isRecording => _isRecording;
+  String? _recordedFilePath;
 
   Future<void> startRecording() async {
     if (!await _recorder.hasPermission()) return;
 
-    _audioBuffer.clear();
     _isRecording = true;
     notifyListeners();
 
-    final stream = await _recorder.startStream(
-      const RecordConfig(encoder: AudioEncoder.pcm16bits, sampleRate: 16000),
+    final dir = await getTemporaryDirectory();
+    _recordedFilePath = '${dir.path}/recorded_audio.wav';
+
+    const cfg = RecordConfig(
+      encoder: AudioEncoder.wav,
+      sampleRate: 16000,
+      bitRate: 128000,
+      numChannels: 1,
     );
 
-    _streamSubscription = stream.listen(
-      (chunk) {
-        _audioBuffer.addAll(chunk);
-      },
-      onError: (err) {
-        print("Error: $err");
-        _isRecording = false;
-        notifyListeners();
-      },
-    );
+    await _recorder.start(cfg, path: _recordedFilePath!);
   }
 
   Future<void> stopRecording() async {
-    await _streamSubscription?.cancel();
     await _recorder.stop();
     _isRecording = false;
     notifyListeners();
   }
 
-  Future<String> saveWavToTempFile(Uint8List wavBytes) async {
-    final dir = await getTemporaryDirectory();
-    final file = File('${dir.path}/recorded_audio.wav');
-    await file.writeAsBytes(wavBytes);
-    return file.path;
-  }
-
   Future<void> playRecording() async {
-    if (_audioBuffer.isEmpty) return;
+    if (_recordedFilePath == null || !File(_recordedFilePath!).existsSync())
+      return;
 
-    final wavBytes = _convertToWav2(Uint8List.fromList(_audioBuffer));
-    final filePath = await saveWavToTempFile(wavBytes);
     try {
-      await _player.setFilePath(filePath);
+      await _player.setFilePath(_recordedFilePath!);
       await _player.play();
     } catch (e) {
       print('Playback failed: $e');
     }
   }
-
-  // --- WAV Header Generator ---
-  Uint8List _convertToWav(Uint8List pcmData) {
-    const sampleRate = 16000;
-    const bitsPerSample = 16;
-    const channels = 1;
-
-    final byteRate = sampleRate * channels * (bitsPerSample ~/ 8);
-    final blockAlign = channels * (bitsPerSample ~/ 8);
-    final dataLength = pcmData.length;
-    final fileSize = 44 + dataLength - 8;
-
-    final header = BytesBuilder();
-    header.add(ascii.encode('RIFF'));
-    header.add(_int32LE(fileSize));
-    header.add(ascii.encode('WAVE'));
-    header.add(ascii.encode('fmt '));
-    header.add(_int32LE(16)); // PCM
-    header.add(_int16LE(1)); // PCM format
-    header.add(_int16LE(channels));
-    header.add(_int32LE(sampleRate));
-    header.add(_int32LE(byteRate));
-    header.add(_int16LE(blockAlign));
-    header.add(_int16LE(bitsPerSample));
-    header.add(ascii.encode('data'));
-    header.add(_int32LE(dataLength));
-    header.add(pcmData);
-
-    return header.toBytes();
-  }
-Uint8List _convertToWav2(Uint8List pcmData) {
-  const sampleRate = 16000;
-  const bitsPerSample = 16;
-  const channels = 1;
-
-  final byteRate = sampleRate * channels * (bitsPerSample ~/ 8);
-  final blockAlign = channels * (bitsPerSample ~/ 8);
-  final dataLength = pcmData.length;
-  final fileSize = 36 + dataLength; // FIXED
-
-  final header = BytesBuilder();
-  header.add(ascii.encode('RIFF'));
-  header.add(_int32LE(fileSize));
-  header.add(ascii.encode('WAVE'));
-  header.add(ascii.encode('fmt '));
-  header.add(_int32LE(16)); // PCM
-  header.add(_int16LE(1)); // PCM format
-  header.add(_int16LE(channels));
-  header.add(_int32LE(sampleRate));
-  header.add(_int32LE(byteRate));
-  header.add(_int16LE(blockAlign));
-  header.add(_int16LE(bitsPerSample));
-  header.add(ascii.encode('data'));
-  header.add(_int32LE(dataLength));
-  header.add(pcmData);
-
-  return header.toBytes();
-}
-
-  List<int> _int16LE(int value) => [value & 0xff, (value >> 8) & 0xff];
-  List<int> _int32LE(int value) => [
-    value & 0xff,
-    (value >> 8) & 0xff,
-    (value >> 16) & 0xff,
-    (value >> 24) & 0xff,
-  ];
 
   @override
   void dispose() {


### PR DESCRIPTION
This pull request refactors the `VoiceRecordViewModel` class to simplify audio recording and playback by eliminating manual stream handling and WAV conversion. The changes also improve code maintainability by leveraging the `record` package's built-in capabilities.

### Refactoring for Simplified Audio Handling:
* Replaced manual audio stream handling and buffer management with direct file-based recording using the `record` package. The `_audioBuffer` and `_streamSubscription` fields, along with their associated logic, were removed. (`lib/view_model/voice_record/voice_record_view_model.dart`, [lib/view_model/voice_record/voice_record_view_model.dartL14-L135](diffhunk://#diff-793e0c169c6108214bbf99808cfde513c61865fdd8e4778b93e44af32d838c05L14-L135))
* Introduced a `_recordedFilePath` field to store the path of the recorded audio file, simplifying playback logic. (`lib/view_model/voice_record/voice_record_view_model.dart`, [lib/view_model/voice_record/voice_record_view_model.dartL14-L135](diffhunk://#diff-793e0c169c6108214bbf99808cfde513c61865fdd8e4778b93e44af32d838c05L14-L135))

### Removal of Custom WAV Conversion:
* Removed custom methods for generating WAV headers (`_convertToWav` and `_convertToWav2`) and associated helper functions (`_int16LE`, `_int32LE`). The `record` package now handles WAV encoding. (`lib/view_model/voice_record/voice_record_view_model.dart`, [lib/view_model/voice_record/voice_record_view_model.dartL14-L135](diffhunk://#diff-793e0c169c6108214bbf99808cfde513c61865fdd8e4778b93e44af32d838c05L14-L135))

### Code Cleanup:
* Removed unused imports (`dart:convert`, `dart:typed_data`) to streamline the file. (`lib/view_model/voice_record/voice_record_view_model.dart`, [lib/view_model/voice_record/voice_record_view_model.dartL2-L4](diffhunk://#diff-793e0c169c6108214bbf99808cfde513c61865fdd8e4778b93e44af32d838c05L2-L4))…fer and stream subscription